### PR TITLE
ENH: enable rocky9 IOC boots

### DIFF
--- a/abl_env.sh
+++ b/abl_env.sh
@@ -4,7 +4,7 @@
 export IOC_USER=ablioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh
 
 ulimit -c unlimited
-

--- a/amo_env.sh
+++ b/amo_env.sh
@@ -4,5 +4,5 @@
 export IOC_USER=amoioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
-
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/amo_env_64.sh
+++ b/amo_env_64.sh
@@ -4,5 +4,5 @@
 export IOC_USER=amoioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
-
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/aux_env.sh
+++ b/aux_env.sh
@@ -4,5 +4,5 @@
 export IOC_USER=auxioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
-
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/common_env.sh
+++ b/common_env.sh
@@ -26,6 +26,9 @@ fi
 if [ "$EPICS_HOST_ARCH" == "linux-x86_64" ]; then
     PROCSERV_VERSION=2.8.0-1.0.0
 fi
+if [ "$EPICS_HOST_ARCH" == "rhel9-x86_64" ]; then
+    PROCSERV_VERSION=2.8.0
+fi
 if [ "$EPICS_HOST_ARCH" == "linux-arm-apalis" ]; then
     PROCSERV_VERSION=2.8.0-1.3.0
     CROSS_ARCH=arm-cortexa9_neon-linux-gnueabihf
@@ -36,6 +39,8 @@ if [ "$EPICS_HOST_ARCH" == "linux-arm-apalis" ]; then
     pythonpathmunge $PACKAGE_SITE_TOP/python/python$PYTHON_VERSION/install/$CROSS_ARCH/lib/python2.7/site-packages
 elif [ -e $PSPKG_ROOT/release/procServ/$PROCSERV_VERSION/$EPICS_HOST_ARCH/bin/procServ ]; then
     pathmunge $PSPKG_ROOT/release/procServ/$PROCSERV_VERSION/$EPICS_HOST_ARCH/bin
+else
+    pathmunge $PACKAGE_SITE_TOP/procServ-$PROCSERV_VERSION/$EPICS_HOST_ARCH/bin
 fi
 export PROCSERV_EXE=`which procServ`
 if [ -n "$PROCSERV_EXE" ]; then

--- a/common_env.sh
+++ b/common_env.sh
@@ -26,9 +26,6 @@ fi
 if [ "$EPICS_HOST_ARCH" == "linux-x86_64" ]; then
     PROCSERV_VERSION=2.8.0-1.0.0
 fi
-if [ "$EPICS_HOST_ARCH" == "rhel9-x86_64" ]; then
-    PROCSERV_VERSION=2.8.0
-fi
 if [ "$EPICS_HOST_ARCH" == "linux-arm-apalis" ]; then
     PROCSERV_VERSION=2.8.0-1.3.0
     CROSS_ARCH=arm-cortexa9_neon-linux-gnueabihf
@@ -40,7 +37,7 @@ if [ "$EPICS_HOST_ARCH" == "linux-arm-apalis" ]; then
 elif [ -e $PSPKG_ROOT/release/procServ/$PROCSERV_VERSION/$EPICS_HOST_ARCH/bin/procServ ]; then
     pathmunge $PSPKG_ROOT/release/procServ/$PROCSERV_VERSION/$EPICS_HOST_ARCH/bin
 else
-    pathmunge $PACKAGE_SITE_TOP/procServ-$PROCSERV_VERSION/$EPICS_HOST_ARCH/bin
+    pathmunge $PACKAGE_SITE_TOP/procServ-ioc/$PROCSERV_VERSION/$EPICS_HOST_ARCH/bin
 fi
 export PROCSERV_EXE=`which procServ`
 if [ -n "$PROCSERV_EXE" ]; then

--- a/cxi_env.sh
+++ b/cxi_env.sh
@@ -4,5 +4,5 @@
 export IOC_USER=cxiioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
-
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/cxi_env_64.sh
+++ b/cxi_env_64.sh
@@ -4,5 +4,5 @@
 export IOC_USER=cxiioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
-
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/det_env.sh
+++ b/det_env.sh
@@ -6,4 +6,5 @@ export IOC_USER=detioc
 export INSTR_GROUP=ps-det
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/fee_env.sh
+++ b/fee_env.sh
@@ -4,5 +4,5 @@
 export IOC_USER=feeioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
-
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/hpl_env.sh
+++ b/hpl_env.sh
@@ -5,5 +5,5 @@ IOC_USER=hplioc
 export IOC_USER=hplioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
-
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/hpl_env_64.sh
+++ b/hpl_env_64.sh
@@ -4,5 +4,5 @@
 export IOC_USER=hplioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
-
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/icl_env.sh
+++ b/icl_env.sh
@@ -4,7 +4,7 @@
 export IOC_USER=iclioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh
 
 ulimit -c unlimited
-

--- a/icl_env_64.sh
+++ b/icl_env_64.sh
@@ -4,5 +4,5 @@
 export IOC_USER=iclioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
-
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/kfe_env.sh
+++ b/kfe_env.sh
@@ -4,5 +4,5 @@
 export IOC_USER=kfeioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
-
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/las_env.sh
+++ b/las_env.sh
@@ -3,5 +3,5 @@
 export IOC_USER=lasioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
-
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/lasdev_env.sh
+++ b/lasdev_env.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# First set your IOC user
+export IOC_USER=lasioc
+
+# Setup the environment needed for consistent launching of soft IOC's
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/lfe_env.sh
+++ b/lfe_env.sh
@@ -4,5 +4,5 @@
 export IOC_USER=lfeioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
-
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/mec_env.sh
+++ b/mec_env.sh
@@ -4,5 +4,5 @@
 export IOC_USER=mecioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
-
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/mfx_env.sh
+++ b/mfx_env.sh
@@ -4,5 +4,5 @@
 export IOC_USER=mfxioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
-
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/rix_env.sh
+++ b/rix_env.sh
@@ -4,7 +4,8 @@
 export IOC_USER=rixioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh
 
 ulimit -c unlimited
 

--- a/rrl_env.sh
+++ b/rrl_env.sh
@@ -5,6 +5,7 @@ export IOC_USER=tstioc
 cfguser=tstioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh
 
 ulimit -c unlimited

--- a/sxr_env.sh
+++ b/sxr_env.sh
@@ -4,5 +4,5 @@
 export IOC_USER=sxrioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
-
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/thz_env.sh
+++ b/thz_env.sh
@@ -4,5 +4,5 @@
 export IOC_USER=thzioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
-
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/tmo_env.sh
+++ b/tmo_env.sh
@@ -4,5 +4,5 @@
 export IOC_USER=tmoioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
-
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/tst_env.sh
+++ b/tst_env.sh
@@ -5,8 +5,8 @@ export IOC_USER=tstioc
 
 # Setup the environment needed for consistent launching of soft IOC's
 #PROCSERV_VERSION=${PROCSERV_VERSION:=2.8.0-1.3.0}
-#source /reg/d/iocCommon/All/common_env.sh
-source /cds/group/pcds/epics-dev/zlentz/iocCommon-All/common_env.sh
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh
 #export PROCSERV_EXE=/reg/g/pcds/epics-dev/bhill/extensions/procServ-git/procServ
 #export PROCSERV="$PROCSERV_EXE --allow --ignore ^D^C --logstamp"
 #pathmunge /reg/g/pcds/epics-dev/bhill/extensions/procServ-git

--- a/tst_env.sh
+++ b/tst_env.sh
@@ -5,7 +5,8 @@ export IOC_USER=tstioc
 
 # Setup the environment needed for consistent launching of soft IOC's
 #PROCSERV_VERSION=${PROCSERV_VERSION:=2.8.0-1.3.0}
-source /reg/d/iocCommon/All/common_env.sh
+#source /reg/d/iocCommon/All/common_env.sh
+source /cds/group/pcds/epics-dev/zlentz/iocCommon-All/common_env.sh
 #export PROCSERV_EXE=/reg/g/pcds/epics-dev/bhill/extensions/procServ-git/procServ
 #export PROCSERV="$PROCSERV_EXE --allow --ignore ^D^C --logstamp"
 #pathmunge /reg/g/pcds/epics-dev/bhill/extensions/procServ-git

--- a/txi_env.sh
+++ b/txi_env.sh
@@ -4,5 +4,5 @@
 export IOC_USER=txiioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
-
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/ued_env.sh
+++ b/ued_env.sh
@@ -6,7 +6,8 @@ export IOC_USER=feeioc
 export INSTR_GROUP=ps-ued
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh
 
 export EPICS_CA_SERVER_PORT=5058
 export EPICS_CA_REPEATER_PORT=5059

--- a/xcs_env_64.sh
+++ b/xcs_env_64.sh
@@ -4,5 +4,5 @@
 export IOC_USER=xcsioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
-
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/xpp_env.sh
+++ b/xpp_env.sh
@@ -6,4 +6,5 @@ export IOC_USER=xppioc
 export INSTR_GROUP=ps-xpp
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh

--- a/xrt_env.sh
+++ b/xrt_env.sh
@@ -4,5 +4,5 @@
 export IOC_USER=feeioc
 
 # Setup the environment needed for consistent launching of soft IOC's
-source /reg/d/iocCommon/All/common_env.sh
-
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "${THIS_DIR}"/common_env.sh


### PR DESCRIPTION
Rocky9 IOCs are currently booting off of this branch in a dev location.
Now that we're in shutdown, I want to merge this into the main branch and switch rocky9 IOCs to booting using the main config area. See https://jira.slac.stanford.edu/browse/ECS-8379

The main change here is the new `else` clause in `common_env.sh`, which directs us to use the new non-`pkg_mgr` builds of `procServ` when the `pkg_mgr` builds are not present. There will likely never be a new release of `pkg_mgr` so this will eventually become the only codepath in use.

All existing IOCs on rhel7 and rhel5 should ignore this new codepath since the legacy builds still exist.

In addition, I've changed the `source common_env.sh` part of every hutch-specific script here to use the same-directory `common_env.sh` script instead of hard-coding the full path. This was required for my testing using a non-standard config area and enables dev area testing in general, but also will be important for the next time we move this folder in the sdf-weka-apocalypse next year.