### PR TITLE
MNT: remove netconfig

### DIFF
--- a/get_hostname.sh
+++ b/get_hostname.sh
@@ -6,11 +6,7 @@ _cfg=`echo $_host | cut -d- -f2`
 
 # If hutch configuration directory doesn't exist, try $CONFIG_SITE_TOP/hosts.byIP
 if [ ! -d $CONFIG_SITE_TOP/$_cfg ]; then
-	if [ -e /reg/common/tools/bin/netconfig ]; then
-		IOC_HOST_IP=`netconfig view $IOC_HOST | egrep "IP:" | sed -e "s/\s*IP:\s*\(\S\+\)\s*/\1/"`
-	else
-		IOC_HOST_IP=`/sbin/ifconfig | /bin/grep -w inet | head -n1 | sed -e 's/ *inet[^0-9]*\([0-9.]*\) .*/\1/'`
-	fi
+	IOC_HOST_IP=`/sbin/ifconfig | /bin/grep -w inet | head -n1 | sed -e 's/ *inet[^0-9]*\([0-9.]*\) .*/\1/'`
 	_host=`awk /$IOC_HOST_IP/'{print $2;}'  $CONFIG_SITE_TOP/hosts.byIP`
 	#echo "Testing: IOC_HOST_IP=$IOC_HOST_IP, _host=$_host"
 fi

--- a/hostname_to_cfg.sh
+++ b/hostname_to_cfg.sh
@@ -15,11 +15,7 @@ fi
 
 # If directory doesn't exist, fall back to using subnet from IP address
 if [ ! -d $CONFIG_SITE_TOP/$cfg ]; then
-	if [ -e /reg/common/tools/bin/netconfig ]; then
-		IOC_HOST_IP=`netconfig view $IOC_HOST | egrep "IP:" | sed -e "s/\s*IP:\s*\(\S\+\)\s*/\1/"`
-	else
-		IOC_HOST_IP=`/sbin/ifconfig | /bin/grep -w inet | head -n1 | sed -e 's/ *inet[^0-9]*\([0-9.]*\) .*/\1/'`
-	fi
+	IOC_HOST_IP=`/sbin/ifconfig | /bin/grep -w inet | head -n1 | sed -e 's/ *inet[^0-9]*\([0-9.]*\) .*/\1/'`
 	IOC_SUBNET=`echo $IOC_HOST_IP | cut -d. -f3`
 	case $IOC_SUBNET in
 		37) cfg=amo; ;;

--- a/hostname_to_cfg.sh
+++ b/hostname_to_cfg.sh
@@ -18,19 +18,21 @@ if [ ! -d $CONFIG_SITE_TOP/$cfg ]; then
 	IOC_HOST_IP=`/sbin/ifconfig | /bin/grep -w inet | head -n1 | sed -e 's/ *inet[^0-9]*\([0-9.]*\) .*/\1/'`
 	IOC_SUBNET=`echo $IOC_HOST_IP | cut -d. -f3`
 	case $IOC_SUBNET in
-		37) cfg=amo; ;;
-		35) cfg=las; ;;
-		68) cfg=cxi; ;;
-		58) cfg=det; ;;
-		36) cfg=fee; ;;
-		64) cfg=hpl; ;;
-		45) cfg=mec; ;;
-		62) cfg=mfx; ;;
-		39) cfg=sxr; ;;
+		36) cfg=ued; ;;
 		57) cfg=thz; ;;
-		42) cfg=tst; ;;
-		43) cfg=xcs; ;;
-		38) cfg=xpp; ;;
+		58) cfg=det; ;;
+		68|69|70) cfg=cxi; ;;
+		72|73|74) cfg=mfx; ;;
+		76|77|78) cfg=mec; ;;
+		80|81|82) cfg=xcs; ;;
+		84|85|86) cfg=xpp; ;;
+		88|89|90) cfg=lfe; ;;
+		92|93|94) cfg=kfe; ;;
+		132|133|134) cfg=tmo; ;;
+		136|137|138) cfg=txi; ;;
+		140|141|142) cfg=rix; ;;
+		148|149|150) cfg=tst; ;;
+		160|161|162) cfg=las; ;;
 	esac
 fi
 echo $cfg


### PR DESCRIPTION
In two places in this repo, netconfig is used to get the IP address of the local host. Let's not do this.

Context is that netconfig is deprecated will be removed: https://jira.slac.stanford.edu/browse/ECS-9486

In addition, one of these scripts had an obviously outdated case statement tree- I've updated it to be correct as far as I can tell.
I could clean up these two scripts even more, but I'm probably not going to touch them any further unless someone thinks it is necessary.

Unlike the other netconfig -> sdfconfig PRs, this could go in before sdfconfig is available, because it doesn't use sdfconfig. Also unlike the others, this needs to be deployed with caution because these are used in the ioc boot process.

Testing:

get_hostname.sh:
- call ./get_hostname.sh from psbuild-rocky9-01, nothing happens (good)
- add copy of hosts.byIP to a folder in my home area, add psbuild-rocky9-01 to it
- CONFIG_SITE_TOP=mydir ./get_hostname.sh, shows psbuild-rocky9-01
- change the name of the server in the file and do it again, shows the new name
- I wanted to try this on the mpod crates, but I can't. I'll hope their OS has ifconfig installed...

hostname_to_cfg.sh
- call it from ctl-tst-dev-01, says tst (good)
- one more time, but use my custom CONFIG_SITE_TOP to make sure the backup branch does something reasonable (some stderr, but correct stdout, good enough)